### PR TITLE
添加用于 Linux 的自动启动脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+account.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install uninstall
+
+entry := csust-network-autologin.desktop
+autostart_entry := ${HOME}/.config/autostart/${entry}
+
+install: ${entry}
+	sed "s#/path/to#$${PWD}#" ${entry} > ${autostart_entry}
+
+uninstall:
+	-rm ${autostart_entry}

--- a/README.md
+++ b/README.md
@@ -1,27 +1,55 @@
 # CSUST_network_auto_login
+
 长沙理工校园网登陆，用于长沙理工大学校园网登陆
+
+**文末还有一个通用的[校园网自动登录脚本介绍](#xdg-autostart)（可用于 csust-lt 等）。**
+
 # 长沙理工大学校园网自动登陆
+
 使用了**魔仙堡魔法**，可以让同学们在连接学校内**csust-bg公用WiFi，或者在办公区连上有线**网络时候可以使用网络。
 因为遭到**赫格沃兹魔法学校**的干扰，账号信息不会公布（公布是不可能公布的，这辈子都不可能公布）
+
 # 使用要求
+
 * 连接上csust-bg 或者办公区有线
+
 # 使用范围
+
 * 能收到csust-bg的地方
 * 教学楼
 * 图书馆
 * 年轮广场
+
 # 使用说明
+
 * 双击
 * 等待
 * 连接上网络之后自动跳转到百度
+
 # 附录
+
 * [项目地址](https://github.com/linfangzhi/CSUST_network_auto_login/)
 * 程序后面有我微信二维码，嘻嘻嘻
 * 因为本人技术有限，暂时先放出windows版本
+
 # 欢迎传播23333
+
 # 下载地址
+
 * 地址一：[点我点我点我](https://github.com/linfangzhi/CSUST_network_auto_login/releases/download/1.0/Auto_login.exe)
 * 地址二：[百度云](https://pan.baidu.com/s/17iOfHhT0WszBBfXBEdK7Gw)提取码: y834
 
-
 [![VRVc6K.md.jpg](https://s2.ax1x.com/2019/06/12/VRVc6K.md.jpg)](https://imgchr.com/i/VRVc6K)
+
+# XDG Autostart
+
+> The XDG Autostart specification defines a method for autostarting ordinary desktop entries on desktop environment startup and removable medium mounting, by placing them in specific #Directories.
+>
+> -- [XDG Autostart - ArchWiki](https://wiki.archlinux.org/title/XDG_Autostart)
+
+使用 Linux 系统重启后校园网登录可能会掉，需要重新登录，所以我以原脚本为基础新建了一个 `login.py`，
+删除了原脚本中像二维码信息和打开浏览器这类开机自启不需要的部分。你可以通过编辑 `login.py` 同一目录下的 [account.txt](account.txt)
+来使用你的校园网账号，也可以直接硬编码到 `login.py` 里。建议将包含密码的文件设为仅自己可见。
+
+还添加了一个 `csust-network-autologin.desktop` 的自启项，通过它来执行校园网自动登录的脚本。使用 `make install` 可以自动修改其中的脚本路径，
+并安装到 XDG Autostart 的配置目录，这样就实现了每次登录桌面环境自动登录的功能。如果之后不需要了，还可以通过 `make uninstall` 删除自启项。

--- a/account.txt
+++ b/account.txt
@@ -1,0 +1,2 @@
+your_account
+your_password

--- a/csust-network-autologin.desktop
+++ b/csust-network-autologin.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Version=0.1.0
+Name=CSUST Network Autologin
+Comment=CSUST Network login script
+Exec="/path/to/login.py"
+StartupNotify=false
+Terminal=false

--- a/login.py
+++ b/login.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import requests
+import re
+import time
+import os
+from colorama import init
+
+init(autoreset=True)
+
+account_info = ['your_account', 'your_password']
+
+def load_account_info():
+    account_file_path = f'{os.path.realpath(os.path.dirname(__file__))}/account.txt'
+
+    with open(account_file_path, 'r') as fd:
+        account_info[0] = fd.readline().rstrip()
+        account_info[1] = fd.readline().rstrip()
+
+    print(account_info)
+
+def login():
+    url = 'http://1.1.1.1'
+    try:
+        a = requests.get(url=url, allow_redirects=False, timeout=5)
+        url2 = a.headers['Location']
+        print(url2)
+        b = str(url2).split('&')
+        wlanuserip = ''
+        wlanacname = ''
+        wlanacip = ''
+        wlanusermac = ''
+
+        for i in b:
+            if 'wlanuserip' in i:
+                wlanuserip = i.split('=')[-1]
+            elif 'wlanacip' in i:
+                wlanacip = i.split('=')[-1]
+            elif 'wlanacname' in i:
+                wlanacname = i.split('=')[-1]
+            elif 'wlanusermac' in i:
+                wlanusermac = i.split('=')[-1][:12]
+                wlanusermac = re.findall(r'\w{1,2}', wlanusermac)
+                wlanusermac = '-'.join(wlanusermac)
+        print("获取相关信息中")
+        print("====================================")
+        print("路由器网关地址:" + wlanuserip)
+        print("连接路由器型号:" + wlanacname)
+        print("用户IP地址:" + wlanacip)
+        print("路由器MAC地址:" + wlanusermac)
+        print("====================================")
+        time.sleep(1)
+        print('开始尝试登陆~~~')
+        time.sleep(2)
+        post_url = 'http://192.168.7.221:801/eportal/?c=ACSetting&a=Login&protocol=http:&hostname=192.168.7.221&iTermType=1&wlanuserip={wlanuserip}&wlanacip={wlanacip}&wlanacname={wlanacname}&mac={wlanusermac}&ip={wlanuserip}&enAdvert=0&queryACIP=0&loginMethod=1'.format(
+            wlanusermac=wlanusermac, wlanacip=wlanacip, wlanacname=wlanacname, wlanuserip=wlanuserip)
+        account = account_info[0]
+        pswd = account_info[-1]
+        data = {
+            'DDDDD': ',0,{}'.format(account),
+            'upass': '{}'.format(pswd),
+            'R1': '0',
+            'R2': '0',
+            'R3': '0',
+            'R6': '0',
+            'para': '00',
+            '0MKKey': '123456',
+        }
+        requests.post(url=post_url, data=data)
+        check()
+    except:
+        print('发起网络请求失败')
+        print('请检查网络是否能访问 1.1.1.1 和 192.168.7.221')
+
+def check():
+    print('\n\n==============')
+    print('''
+    注意!!
+    首先连接上WiFi “csust—bg” 或者插上办公区的网线\n
+    ''')
+    print('本程序仅供学习用途\n')
+    print('=============\n')
+    print('检查网络中~~~~~~,请稍后')
+    try:
+        a = requests.get('https://www.baidu.com', timeout=1).text
+    except:
+        a = '0'
+    if 'About Baidu' in a:
+        print('\n==============')
+        print('     登录成功')
+        print('    程序准备退出')
+        print('=============\n')
+        return True
+    else:
+        print('断网或者连接失败，尝试登陆中~~~~~')
+        print('正在连接~~~')
+        login()
+
+def main():
+    load_account_info()
+    check()
+
+if __name__ == '__main__':
+    main()

--- a/login.py
+++ b/login.py
@@ -4,9 +4,9 @@ import requests
 import re
 import time
 import os
-from colorama import init
-
-init(autoreset=True)
+# from colorama import init
+#
+# init(autoreset=True)
 
 account_info = ['your_account', 'your_password']
 
@@ -17,7 +17,7 @@ def load_account_info():
         account_info[0] = fd.readline().rstrip()
         account_info[1] = fd.readline().rstrip()
 
-    print(account_info)
+    print('Account:', account_info[0])
 
 def login():
     url = 'http://1.1.1.1'


### PR DESCRIPTION
> 使用 Linux 系统重启后校园网登录可能会掉，需要重新登录，所以我以原脚本为基础新建了一个 `login.py`，
> 删除了原脚本中像二维码信息和打开浏览器这类开机自启不需要的部分。你可以通过编辑 `login.py` 同一目录下的 account.txt
> 来使用你的校园网账号，也可以直接硬编码到 `login.py` 里。建议将包含密码的文件设为仅自己可见。
>
> 还添加了一个 `csust-network-autologin.desktop` 的自启项，通过它来执行校园网自动登录的脚本。使用 `make install` 可以自动修改其中的脚本路径，
>并安装到 XDG Autostart 的配置目录，这样就实现了每次登录桌面环境自动登录的功能。如果之后不需要了，还可以通过 `make uninstall` 删除自启项。
>
> -- README.md